### PR TITLE
fix: pass Python3_EXECUTABLE to cmake to fix Boost.Python mismatch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ def build_cpp_extensions():
                 "cmake",
                 str(project_path),
                 f"-DCMAKE_INSTALL_PREFIX={install_dir}",
+                f"-DPython3_EXECUTABLE={sys.executable}",
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-Wno-dev"  # Suppress developer warnings
             ]


### PR DESCRIPTION
## Summary

- cmake に `-DPython3_EXECUTABLE={sys.executable}` を渡すよう setup.py を修正

## Background

`find_package(Python3)` が PATH 上の別バージョン（例: Python 3.12）を検出すると、`Boost::python312` を要求するが、システムの Boost Python は `libboost_python310` しかないためビルドが失敗する。

```
No suitable build variant has been found.
* libboost_python310.so.1.74.0 (3.10, Boost_PYTHON_VERSION=3.12)
```

`sys.executable` を明示的に渡すことで、ビルドを実行している Python とBoost Python のバージョンが一致するようになる。

## Test plan

- [ ] 複数の Python バージョンがインストールされた環境で `pip install` / `uv sync` が成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)